### PR TITLE
fix: explicitly set os-disk to `Premium_LRS`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -51,6 +51,11 @@ resource "azurerm_orchestrated_virtual_machine_scale_set" "firezone" {
     }
   }
 
+  os_disk {
+    caching              = "None"
+    storage_account_type = "Premium_LRS"
+  }
+
   extension {
     name                 = "firezone-gateway-install"
     publisher            = "Microsoft.Azure.Extensions"


### PR DESCRIPTION
It appears that leaving this as the default makes terraform taint the VMSS on every deploy. `PremiumLRS` appears to be the default and refers to an SSD.