### PR TITLE
fix: allow passing an IPv6 prefix

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -40,7 +40,7 @@ resource "azurerm_orchestrated_virtual_machine_scale_set" "firezone" {
           name                = "public-ipv6"
           version             = "IPv6"
           public_ip_prefix_id = var.public_ipv6_prefix
-          sku_name            = "Standard_Global"
+          sku_name            = "Standard_Regional"
         }
       }
     }

--- a/main.tf
+++ b/main.tf
@@ -30,12 +30,16 @@ resource "azurerm_orchestrated_virtual_machine_scale_set" "firezone" {
     }
 
     dynamic "ip_configuration" {
-      for_each = var.private_subnet_ipv6 != null ? [1] : []
+      for_each = var.public_ipv6_prefix != null ? [1] : []
       content {
-        name      = "internal-ipv6"
-        primary   = false
-        subnet_id = var.private_subnet_ipv6
-        version   = "IPv6"
+        name    = "internal-ipv6"
+        primary = false
+        version = "IPv6"
+        public_ip_address {
+          name                = "public-ipv6"
+          version             = "IPv6"
+          public_ip_prefix_id = var.public_ipv6_prefix
+        }
       }
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -32,9 +32,10 @@ resource "azurerm_orchestrated_virtual_machine_scale_set" "firezone" {
     dynamic "ip_configuration" {
       for_each = var.public_ipv6_prefix != null ? [1] : []
       content {
-        name    = "internal-ipv6"
-        primary = false
-        version = "IPv6"
+        name      = "internal-ipv6"
+        primary   = false
+        subnet_id = var.private_subnet
+        version   = "IPv6"
         public_ip_address {
           name                = "public-ipv6"
           version             = "IPv6"

--- a/main.tf
+++ b/main.tf
@@ -40,6 +40,7 @@ resource "azurerm_orchestrated_virtual_machine_scale_set" "firezone" {
           name                = "public-ipv6"
           version             = "IPv6"
           public_ip_prefix_id = var.public_ipv6_prefix
+          sku_name            = "Standard_Global"
         }
       }
     }

--- a/variables.tf
+++ b/variables.tf
@@ -77,8 +77,8 @@ variable "private_subnet" {
   type        = string
 }
 
-variable "private_subnet_ipv6" {
-  description = "The private IPv6 subnet ID"
+variable "public_ipv6_prefix" {
+  description = "The public IPv6 prefix to use"
   type        = string
   default     = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -73,7 +73,7 @@ variable "firezone_api_url" {
 }
 
 variable "private_subnet" {
-  description = "The private IPv4 subnet ID"
+  description = "The private subnet ID"
   type        = string
 }
 


### PR DESCRIPTION
The IPv6 support we have added in #5 is broken. IPv6 must be configured on the VM instances directly. To do so, we allow passing an IPv6 prefix id that the individual VMs can then allocate from.